### PR TITLE
Fix unique names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,17 @@
 % stack build
 ```
 * We can investigate things in the repl if we enable the quasiquotes language
-  extension. The ghci session will be cleaner if we supress a couple of warnings.
+  extension.
 ```haskell
 % stack repl
-> :set -XQuasiQuotes -fno-warn-name-shadowing -fno-warn-unused-matches
-> data Agent = A { x :: Double } deriving (Eq, Show)
+> :set -XQuasiQuotes
+> data Agent = A { a :: Double } deriving (Eq, Show)
 >
 > -- The line that follows is a rule applied to state and time.
-> [rule| A{x=x} --> A{x='x+1'} @'x' |] (ms [A{x=1}, A{x=1}, A{x=2}, A{x=3}]) 5.0
-[ Rxn {lhs = [(A {x = 1.0},1)], rhs = [(A {x = 2.0},1)], rate = 2.0}
-, Rxn {lhs = [(A {x = 2.0},1)], rhs = [(A {x = 3.0},1)], rate = 2.0}
-, Rxn {lhs = [(A {x = 3.0},1)], rhs = [(A {x = 4.0},1)], rate = 3.0}
-]
+> [rule| A{a=x} --> A{a='x+1'} @'x' |] (ms [A{a=1}, A{a=1}, A{a=2}, A{a=3}]) 5.0
+[ Rxn {lhs = [(A {a = 1.0},1)], rhs = [(A {a = 2.0},1)], rate = 2.0}
+, Rxn {lhs = [(A {a = 2.0},1)], rhs = [(A {a = 3.0},1)], rate = 2.0}
+, Rxn {lhs = [(A {a = 3.0},1)], rhs = [(A {a = 4.0},1)], rate = 3.0}
 ```
 or
 * Write a model to a file and then load in the repl (see example models in the /models directory)

--- a/src/Chromar/RExprs.hs
+++ b/src/Chromar/RExprs.hs
@@ -4,7 +4,7 @@ import Prelude hiding (exp)
 import Data.Fixed (mod')
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
-import Data.Set (Set)
+import Data.Set (Set, member)
 import Data.Functor.Identity
 import qualified Data.Set as Set
 import Language.Haskell.Meta.Parse
@@ -269,7 +269,10 @@ timeExp = VarE $ mkName "t"
 
 mkLiftExp :: Set Name -> Exp -> Exp
 mkLiftExp nms body = LamE args (lExp nms body) where
-    args = [VarP $ mkName "s", VarP $ mkName "t"]
+    args =
+        [ let s = mkName "s" in if s `member` nms then VarP s else WildP
+        , let t = mkName "t" in if t `member` nms then VarP t else WildP
+        ]
 
 mkWhenExp :: Exp -> Exp -> Exp -> Exp
 mkWhenExp eb e1 e2 = AppE (AppE (VarE $ mkName "orElse") whenE) e2 where


### PR DESCRIPTION
https://github.com/azardilis/Chromar/issues/8#issuecomment-643993449 replace unused arg names with wildcard underscores and with the REPL example code, use `a` as the field name to avoid name shadowing.